### PR TITLE
Alias Handlebars::Context and Handlebars::SafeString unless defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ template = minibars.compile("{{safe}}")
 template.call(safe: Minibars::SafeString.new("<pre>Totally Safe!<pre>"))
 ```
 
+## Compatibility
+
+`Handlebars::Context` aliases `Minibars::Context` and `Handlebars::SafeString` aliases `Minibars::SafeString` unless they are already defined.
+
 ## Limitations
 
 - No Ruby helpers

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 0.2.0
+
+More Handlebars.rb compatibility
+
+- `Handlebars::Context` aliases `Minibars::Context` and `Handlebars::SafeString` aliases `Minibars::SafeString` unless they are already defined.

--- a/lib/minibars.rb
+++ b/lib/minibars.rb
@@ -147,3 +147,9 @@ module Minibars
     end
   end
 end
+
+# Let's be as Handlebars.rb compatible as we can!
+  module Handlebars
+    Context = Minibars::Context unless defined? Context
+    SafeString = Minibars::SafeString unless defined? SafeString
+  end

--- a/spec/minibars/handlebars_compatiblity_spec.rb
+++ b/spec/minibars/handlebars_compatiblity_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Handlebars do
+  describe "::Context" do
+    it "should alias Minibars::Context" do
+      expect(Handlebars::Context).to eq Minibars::Context
+    end
+  end
+
+  describe "::SafeString" do
+    it "should alias Minibars::SafeString" do
+      expect(Handlebars::SafeString).to eq Minibars::SafeString
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/combinaut/minibars/issues/2

Should we alias Minibars::Template also?  It doesn't seem necessary.  But, what do you think?